### PR TITLE
builds where failing on saucy this fixes the issue, so it builds again

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,9 @@ LT_INIT([disable-static])
 # Configure build system and tools
 AM_SILENT_RULES([yes])
 
+#fix for modern automake
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+
 # Check for utilities
 AC_PROG_CC
 AC_PROG_SED


### PR DESCRIPTION
dont fully understand this but looking around this should fix building on 13.10 currently it breaks on running autoreconf -f -i during packaging.
