### PR TITLE
unload python plugins when geanypy is deactivated

### DIFF
--- a/build
+++ b/build
@@ -1,0 +1,1 @@
+make clean && make -j8 && sudo make install && sudo cp src/.libs/geanypy.so /usr/lib/x86_64-linux-gnu/geany/geanypy.so

--- a/geany/manager.py
+++ b/geany/manager.py
@@ -47,6 +47,12 @@ class PluginManager(gtk.Dialog):
 		action_area.pack_start(btn, False, True, 0)
 		btn.show()
 
+		btn_refresh = gtk.Button(stock=gtk.STOCK_REFRESH)
+		btn_refresh.set_border_width(6)
+		btn_refresh.connect("clicked", lambda x: self.load_sorted_plugins_info())
+		action_area.pack_start(btn_refresh, False, True, 0)
+		btn_refresh.show()
+
 		self.btn_help = gtk.Button(stock=gtk.STOCK_HELP)
 		self.btn_help.set_border_width(6)
 		self.btn_help.set_no_show_all(True)
@@ -97,21 +103,21 @@ class PluginManager(gtk.Dialog):
 		self.loader.unload_all_plugins()
 
 	def load_plugins_list(self):
-		liststore = gtk.ListStore(gobject.TYPE_BOOLEAN, str, str)
+		self.liststore = gtk.ListStore(gobject.TYPE_BOOLEAN, str, str)
 
 		self.btn_help.connect("clicked",
-			self.on_help_button_clicked, self.treeview, liststore)
+			self.on_help_button_clicked, self.treeview, self.liststore)
 
 		self.btn_prefs.connect("clicked",
-			self.on_preferences_button_clicked, self.treeview, liststore)
+			self.on_preferences_button_clicked, self.treeview, self.liststore)
 
-		self.treeview.set_model(liststore)
+		self.treeview.set_model(self.liststore)
 		self.treeview.set_headers_visible(False)
 		self.treeview.set_grid_lines(True)
 
 		check_renderer = gtk.CellRendererToggle()
 		check_renderer.set_radio(False)
-		check_renderer.connect('toggled', self.on_plugin_load_toggled, liststore)
+		check_renderer.connect('toggled', self.on_plugin_load_toggled, self.liststore)
 		text_renderer = gtk.CellRendererText()
 
 		check_column = gtk.TreeViewColumn(None, check_renderer, active=0)
@@ -121,15 +127,16 @@ class PluginManager(gtk.Dialog):
 		self.treeview.append_column(text_column)
 
 		self.treeview.connect('row-activated',
-			self.on_row_activated, check_renderer, liststore)
+			self.on_row_activated, check_renderer, self.liststore)
 		self.treeview.connect('cursor-changed',
-			self.on_selected_plugin_changed, liststore)
+			self.on_selected_plugin_changed, self.liststore)
 
-		self.load_sorted_plugins_info(liststore)
+		self.load_sorted_plugins_info()
 
 
-	def load_sorted_plugins_info(self, list_store):
+	def load_sorted_plugins_info(self):
 
+		self.liststore.clear()
 		plugin_info_list = list(self.loader.iter_plugin_info())
 		#plugin_info_list.sort(key=lambda pi: pi[1])
 
@@ -146,7 +153,7 @@ class PluginManager(gtk.Dialog):
 
 			loaded = plugin_info.filename in self.loader.plugins
 
-			list_store.append([loaded, lbl, plugin_info.filename])
+			self.liststore.append([loaded, lbl, plugin_info.filename])
 
 
 	def on_selected_plugin_changed(self, treeview, model):

--- a/geany/manager.py
+++ b/geany/manager.py
@@ -49,7 +49,7 @@ class PluginManager(gtk.Dialog):
 
 		btn_refresh = gtk.Button(stock=gtk.STOCK_REFRESH)
 		btn_refresh.set_border_width(6)
-		btn_refresh.connect("clicked", lambda x: self.load_sorted_plugins_info())
+		btn_refresh.connect("clicked", lambda x: self.on_refresh_plugins())
 		action_area.pack_start(btn_refresh, False, True, 0)
 		btn_refresh.show()
 
@@ -69,6 +69,9 @@ class PluginManager(gtk.Dialog):
 
 		self.load_plugins_list()
 
+	def on_refresh_plugins(self):
+		print("not implemented yet")
+		pass
 
 	def on_help_button_clicked(self, button, treeview, model):
 		path = treeview.get_cursor()[0]

--- a/geany/manager.py
+++ b/geany/manager.py
@@ -49,7 +49,7 @@ class PluginManager(gtk.Dialog):
 
 		btn_refresh = gtk.Button(stock=gtk.STOCK_REFRESH)
 		btn_refresh.set_border_width(6)
-		btn_refresh.connect("clicked", lambda x: self.on_refresh_plugins())
+		btn_refresh.connect("clicked", self.on_refresh_plugins)
 		action_area.pack_start(btn_refresh, False, True, 0)
 		btn_refresh.show()
 
@@ -69,9 +69,8 @@ class PluginManager(gtk.Dialog):
 
 		self.load_plugins_list()
 
-	def on_refresh_plugins(self):
-		print("not implemented yet")
-		pass
+	def on_refresh_plugins(self, button):
+		self.loader.refresh_plugins()
 
 	def on_help_button_clicked(self, button):
 		path = self.treeview.get_cursor()[0]
@@ -108,11 +107,9 @@ class PluginManager(gtk.Dialog):
 	def load_plugins_list(self):
 		self.liststore = gtk.ListStore(gobject.TYPE_BOOLEAN, str, str)
 
-		self.btn_help.connect("clicked",
-			self.on_help_button_clicked)
+		self.btn_help.connect("clicked", self.on_help_button_clicked)
 
-		self.btn_prefs.connect("clicked",
-			self.on_preferences_button_clicked)
+		self.btn_prefs.connect("clicked", self.on_preferences_button_clicked)
 
 		self.treeview.set_model(self.liststore)
 		self.treeview.set_headers_visible(False)

--- a/geany/manager.py
+++ b/geany/manager.py
@@ -89,10 +89,12 @@ class PluginManager(gtk.Dialog):
 	def activate_plugin(self, filename):
 		self.loader.load_plugin(filename)
 
-
 	def deactivate_plugin(self, filename):
 		self.loader.unload_plugin(filename)
 
+	def deactivate_all_plugins(self):
+		self.response(gtk.RESPONSE_CLOSE)
+		self.loader.unload_all_plugins()
 
 	def load_plugins_list(self):
 		liststore = gtk.ListStore(gobject.TYPE_BOOLEAN, str, str)

--- a/geany/manager.py
+++ b/geany/manager.py
@@ -73,10 +73,10 @@ class PluginManager(gtk.Dialog):
 		print("not implemented yet")
 		pass
 
-	def on_help_button_clicked(self, button, treeview, model):
-		path = treeview.get_cursor()[0]
-		iter = model.get_iter(path)
-		filename = model.get_value(iter, 2)
+	def on_help_button_clicked(self, button):
+		path = self.treeview.get_cursor()[0]
+		iter = self.liststore.get_iter(path)
+		filename = self.liststore.get_value(iter, 2)
 		for plugin in self.loader.available_plugins:
 			if plugin.filename == filename:
 				plugin.cls.show_help()
@@ -85,10 +85,10 @@ class PluginManager(gtk.Dialog):
 			print("Plugin does not support help function")
 
 
-	def on_preferences_button_clicked(self, button, treeview, model):
-		path = treeview.get_cursor()[0]
-		iter = model.get_iter(path)
-		filename = model.get_value(iter, 2)
+	def on_preferences_button_clicked(self, button):
+		path = self.treeview.get_cursor()[0]
+		iter = self.liststore.get_iter(path)
+		filename = self.liststore.get_value(iter, 2)
 		try:
 			self.loader.plugins[filename].show_configure()
 		except KeyError:
@@ -109,10 +109,10 @@ class PluginManager(gtk.Dialog):
 		self.liststore = gtk.ListStore(gobject.TYPE_BOOLEAN, str, str)
 
 		self.btn_help.connect("clicked",
-			self.on_help_button_clicked, self.treeview, self.liststore)
+			self.on_help_button_clicked)
 
 		self.btn_prefs.connect("clicked",
-			self.on_preferences_button_clicked, self.treeview, self.liststore)
+			self.on_preferences_button_clicked)
 
 		self.treeview.set_model(self.liststore)
 		self.treeview.set_headers_visible(False)
@@ -120,7 +120,7 @@ class PluginManager(gtk.Dialog):
 
 		check_renderer = gtk.CellRendererToggle()
 		check_renderer.set_radio(False)
-		check_renderer.connect('toggled', self.on_plugin_load_toggled, self.liststore)
+		check_renderer.connect('toggled', self.on_plugin_load_toggled)
 		text_renderer = gtk.CellRendererText()
 
 		check_column = gtk.TreeViewColumn(None, check_renderer, active=0)
@@ -130,9 +130,9 @@ class PluginManager(gtk.Dialog):
 		self.treeview.append_column(text_column)
 
 		self.treeview.connect('row-activated',
-			self.on_row_activated, check_renderer, self.liststore)
+			self.on_row_activated, check_renderer)
 		self.treeview.connect('cursor-changed',
-			self.on_selected_plugin_changed, self.liststore)
+			self.on_selected_plugin_changed)
 
 		self.load_sorted_plugins_info()
 
@@ -159,12 +159,12 @@ class PluginManager(gtk.Dialog):
 			self.liststore.append([loaded, lbl, plugin_info.filename])
 
 
-	def on_selected_plugin_changed(self, treeview, model):
+	def on_selected_plugin_changed(self, treeview):
 
-		path = treeview.get_cursor()[0]
-		iter = model.get_iter(path)
-		filename = model.get_value(iter, 2)
-		active = model.get_value(iter, 0)
+		path = self.treeview.get_cursor()[0]
+		iter = self.liststore.get_iter(path)
+		filename = self.liststore.get_value(iter, 2)
+		active = self.liststore.get_value(iter, 0)
 
 		if self.loader.plugin_has_configure(filename):
 			self.btn_prefs.set_visible(True)
@@ -177,15 +177,15 @@ class PluginManager(gtk.Dialog):
 			self.btn_help.set_visible(False)
 
 
-	def on_plugin_load_toggled(self, cell, path, model):
+	def on_plugin_load_toggled(self, cell, path):
 		active = not cell.get_active()
-		iter = model.get_iter(path)
-		model.set_value(iter, 0, active)
+		iter = self.liststore.get_iter(path)
+		self.liststore.set_value(iter, 0, active)
 		if active:
-			self.activate_plugin(model.get_value(iter, 2))
+			self.activate_plugin(self.liststore.get_value(iter, 2))
 		else:
-			self.deactivate_plugin(model.get_value(iter, 2))
+			self.deactivate_plugin(self.liststore.get_value(iter, 2))
 
 
-	def on_row_activated(self, tvw, path, view_col, cell, model):
-		self.on_plugin_load_toggled(cell, path, model)
+	def on_row_activated(self, tvw, path, view_col, cell):
+		self.on_plugin_load_toggled(cell, path)

--- a/src/geanypy-plugin.c
+++ b/src/geanypy-plugin.c
@@ -271,9 +271,11 @@ plugin_init(GeanyData *data)
 		G_CALLBACK(on_python_plugin_loader_activate), NULL);
 }
 
-
 G_MODULE_EXPORT void plugin_cleanup(void)
 {
+	PyObject* m = PyObject_GetAttrString(manager, "deactivate_all_plugins");
+	PyObject_CallObject(m, NULL);
+
     signal_manager_free(signal_manager);
     Py_XDECREF(manager);
 	GeanyPy_stop_interpreter();

--- a/src/geanypy-plugin.c
+++ b/src/geanypy-plugin.c
@@ -39,6 +39,8 @@ static GtkWidget *loader_item = NULL;
 static PyObject *manager = NULL;
 static gchar *plugin_dir = NULL;
 static SignalManager *signal_manager = NULL;
+static GtkToolItem* toolbar_button = NULL;
+
 
 
 /* Forward declarations to prevent compiler warnings. */
@@ -269,10 +271,25 @@ plugin_init(GeanyData *data)
 	gtk_widget_show(loader_item);
 	g_signal_connect(loader_item, "activate",
 		G_CALLBACK(on_python_plugin_loader_activate), NULL);
+
+	toolbar_button = gtk_tool_button_new_from_stock(GTK_STOCK_ADD);
+	if (toolbar_button != NULL)
+	{
+		plugin_add_toolbar_item(geany_plugin, toolbar_button);
+		ui_add_document_sensitive(GTK_WIDGET(toolbar_button));
+
+		g_signal_connect(toolbar_button, "clicked",
+			G_CALLBACK(on_python_plugin_loader_activate), NULL);
+
+		gtk_widget_show(GTK_WIDGET(toolbar_button));
+	}
 }
 
 G_MODULE_EXPORT void plugin_cleanup(void)
 {
+	if (toolbar_button != NULL)
+		gtk_widget_destroy(GTK_WIDGET(toolbar_button));
+
     PyObject* deactivate_all_plugins = PyObject_GetAttrString(manager, "deactivate_all_plugins");
     if (deactivate_all_plugins == NULL)
     {

--- a/src/geanypy-plugin.c
+++ b/src/geanypy-plugin.c
@@ -273,8 +273,14 @@ plugin_init(GeanyData *data)
 
 G_MODULE_EXPORT void plugin_cleanup(void)
 {
-	PyObject* m = PyObject_GetAttrString(manager, "deactivate_all_plugins");
-	PyObject_CallObject(m, NULL);
+    PyObject* deactivate_all_plugins = PyObject_GetAttrString(manager, "deactivate_all_plugins");
+    if (deactivate_all_plugins == NULL)
+    {
+        g_warning(_("Unable to get deactivate_all_plugins() method on plugin manager"));
+        return;
+    }
+    PyObject_CallObject(deactivate_all_plugins, NULL);
+    Py_DECREF(deactivate_all_plugins);
 
     signal_manager_free(signal_manager);
     Py_XDECREF(manager);

--- a/src/geanypy-plugin.c
+++ b/src/geanypy-plugin.c
@@ -266,38 +266,40 @@ plugin_init(GeanyData *data)
         GeanyPy_init_manager(plugin_dir);
 
     loader_item = gtk_menu_item_new_with_label(_("Python Plugin Manager"));
-	gtk_widget_set_sensitive(loader_item, plugin_dir != NULL);
-	gtk_menu_append(GTK_MENU(geany->main_widgets->tools_menu), loader_item);
-	gtk_widget_show(loader_item);
-	g_signal_connect(loader_item, "activate",
-		G_CALLBACK(on_python_plugin_loader_activate), NULL);
+    gtk_widget_set_sensitive(loader_item, plugin_dir != NULL);
+    gtk_menu_append(GTK_MENU(geany->main_widgets->tools_menu), loader_item);
+    gtk_widget_show(loader_item);
+    g_signal_connect(loader_item, "activate",
+            G_CALLBACK(on_python_plugin_loader_activate), NULL);
 
-	toolbar_button = gtk_tool_button_new_from_stock(GTK_STOCK_ADD);
-	if (toolbar_button != NULL)
-	{
-		plugin_add_toolbar_item(geany_plugin, toolbar_button);
-		ui_add_document_sensitive(GTK_WIDGET(toolbar_button));
+    toolbar_button = gtk_tool_button_new_from_stock(GTK_STOCK_ADD);
+    if (toolbar_button != NULL)
+    {
+        plugin_add_toolbar_item(geany_plugin, toolbar_button);
+        ui_add_document_sensitive(GTK_WIDGET(toolbar_button));
 
-		g_signal_connect(toolbar_button, "clicked",
-			G_CALLBACK(on_python_plugin_loader_activate), NULL);
+        g_signal_connect(toolbar_button, "clicked",
+                G_CALLBACK(on_python_plugin_loader_activate), NULL);
 
-		gtk_widget_show(GTK_WIDGET(toolbar_button));
-	}
+        gtk_widget_show(GTK_WIDGET(toolbar_button));
+    }
 }
 
 G_MODULE_EXPORT void plugin_cleanup(void)
 {
-	if (toolbar_button != NULL)
-		gtk_widget_destroy(GTK_WIDGET(toolbar_button));
+    if (toolbar_button != NULL)
+        gtk_widget_destroy(GTK_WIDGET(toolbar_button));
 
-    PyObject* deactivate_all_plugins = PyObject_GetAttrString(manager, "deactivate_all_plugins");
-    if (deactivate_all_plugins == NULL)
+    PyObject* deactivate_all_plugins = PyObject_GetAttrString(manager,
+            "deactivate_all_plugins");
+    if (deactivate_all_plugins != NULL)
     {
-        g_warning(_("Unable to get deactivate_all_plugins() method on plugin manager"));
-        return;
+        PyObject* r = PyObject_CallObject(deactivate_all_plugins, NULL);
+        if (r)
+            Py_DECREF(r);
+        Py_DECREF(deactivate_all_plugins);
+
     }
-    PyObject_CallObject(deactivate_all_plugins, NULL);
-    Py_DECREF(deactivate_all_plugins);
 
     signal_manager_free(signal_manager);
     Py_XDECREF(manager);


### PR DESCRIPTION
This should fix bug #12 
when the geanypy plugin's cleanup is called it closes the python plugin manager and unloads all the python plugins