### PR TITLE
unload python plugins when geanypy is deactivated

### DIFF
--- a/geany/manager.py
+++ b/geany/manager.py
@@ -93,6 +93,9 @@ class PluginManager(gtk.Dialog):
 	def deactivate_plugin(self, filename):
 		self.loader.unload_plugin(filename)
 
+	def deactivate_all_plugins(self):
+		self.response(gtk.RESPONSE_CLOSE)
+		self.loader.unload_all_plugins()
 
 	def load_plugins_list(self):
 		liststore = gtk.ListStore(gobject.TYPE_BOOLEAN, str, str)

--- a/src/geanypy-plugin.c
+++ b/src/geanypy-plugin.c
@@ -274,6 +274,17 @@ plugin_init(GeanyData *data)
 
 G_MODULE_EXPORT void plugin_cleanup(void)
 {
+    PyObject* deactivate_all_plugins = PyObject_GetAttrString(manager,
+            "deactivate_all_plugins");
+    if (deactivate_all_plugins != NULL)
+    {
+        PyObject* r = PyObject_CallObject(deactivate_all_plugins, NULL);
+        if (r)
+            Py_DECREF(r);
+        Py_DECREF(deactivate_all_plugins);
+
+    }
+
     signal_manager_free(signal_manager);
     Py_XDECREF(manager);
 	GeanyPy_stop_interpreter();


### PR DESCRIPTION
fixed memory leak, corrected formatting

fix for  Geany Crashes if Geanypy is closed with the python console open #12
added call to deactivate all plugins from the C geany plugin to the python plugin manager, it is called from the geanypy's clean up function

changed indents back to tabs